### PR TITLE
Fix competing axes in smart component locations

### DIFF
--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -1,4 +1,5 @@
 import pathlib
+from collections import defaultdict
 from os import PathLike
 from typing import Any
 
@@ -211,6 +212,8 @@ class GlyphsBackend:
             )
             layers[layerName] = gsLayerToFontraLayer(gsLayer, self.axisNames)
 
+        fixLocations(sources, set(smartLocation))
+
         glyph = VariableGlyph(
             name=glyphName,
             axes=localAxes,
@@ -297,6 +300,34 @@ class GlyphsBackend:
 
     async def aclose(self) -> None:
         pass
+
+
+def fixLocations(sources, smartAxisNames):
+    # If a set of sources is equally controlled by a font axis and a glyph axis
+    # (smart axis), then the font axis should be ignored. This makes our
+    # varLib-based variation model behave like Glyphs.
+    sets = defaultdict(set)
+    for i, source in enumerate(sources):
+        for locItem in source.location.items():
+            sets[locItem].add(i)
+
+    reverseSets = defaultdict(set)
+    for locItem, sourceIndices in sets.items():
+        reverseSets[tuple(sorted(sourceIndices))].add(locItem)
+
+    matches = [locItems for locItems in reverseSets.values() if len(locItems) > 1]
+
+    locItemsToDelete = []
+    for locItems in matches:
+        for axis, value in locItems:
+            if axis not in smartAxisNames:
+                locItemsToDelete.append((axis, value))
+
+    if locItemsToDelete:
+        for axis, value in locItemsToDelete:
+            for source in sources:
+                if source.location.get(axis) == value:
+                    del source.location[axis]
 
 
 class GlyphsPackageBackend(GlyphsBackend):

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -323,11 +323,10 @@ def fixLocations(sources, smartAxisNames):
             if axis not in smartAxisNames:
                 locItemsToDelete.append((axis, value))
 
-    if locItemsToDelete:
-        for axis, value in locItemsToDelete:
-            for source in sources:
-                if source.location.get(axis) == value:
-                    del source.location[axis]
+    for axis, value in locItemsToDelete:
+        for source in sources:
+            if source.location.get(axis) == value:
+                del source.location[axis]
 
 
 class GlyphsPackageBackend(GlyphsBackend):


### PR DESCRIPTION
In Glyphs, it is possible for a glyph axis (smart component axis) to compete with a font axis. As is, this makes the glyph behave differently with fontTools.varLib than in Glyphs itself.

For example, take a smart component with an axis called MyAxis. The smart component has two sources, one is at Weight=0,MyAxis=0, and the other is at Weight=1000,MyAxis=1000. It appears both axes would have equal control over the final location of the smart component. In practice, in Glyphs, only the glyph axis is important, and the font axis location is ignored. In other words, the glyph axis takes precedence.

This PR fixes source locations in situations where this occurs, making the variable component work correctly in our fontTools.varLib based world.