### PR TITLE
Don't crash on missing components glyphs

### DIFF
--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -409,6 +409,9 @@ class GlyphsBackend:
         for layer in gsGlyph.layers:
             for component in layer.components:
                 componentNames.add(component.name)
+            if layer.hasBackground:
+                for component in layer.background.components:
+                    componentNames.add(component.name)
 
         for compoName in sorted(componentNames):
             if compoName not in self.glyphNameToIndex:

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -411,6 +411,8 @@ class GlyphsBackend:
                 componentNames.add(component.name)
 
         for compoName in sorted(componentNames):
+            if compoName not in self.glyphNameToIndex:
+                continue
             self._ensureGlyphIsParsed(compoName)
 
     def _getBraceLayerLocation(self, gsLayer):


### PR DESCRIPTION
Also: pre-parse component glyphs referenced by layer backgrounds.