### PR TITLE
Read and write OpenType features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,17 @@ It supports the following features:
 - Brace layers
 - Smart components (for now restricted to interpolation: axis values need to be within the minimum and maximum values)
 
-
 ### Writing is currently limited to ...
 
 #### Glyph Layer
+
 - Contour (Paths, Nodes) ✅
 - (Smart) Components ✅
 - Anchors ✅
 - Guidelines ✅
+
+#### Features
+
+- featurePrefixes ✅
+- features ✅
+- classes ✅

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -303,11 +303,17 @@ class GlyphsBackend:
                 f"GlyphsApp Backend: Error while parsing features: {e}"
             )
 
+        self._writeFontData()
+
+    def _writeFontData(self):
         # Set self.gsFont.glyphs to an empty list temporarily, so no time is wasted on these.
-        gsFontTemp = deepcopy(self.gsFont)
-        gsFontTemp.glyphs = []
-        self.rawFontData = self._getRawData(gsFontTemp)
-        self._writeRawFontData()
+        originalGlyphs = self.gsFont.glyphs
+        self.gsFont.glyphs.glyphs = []
+        try:
+            self.rawFontData = self._getRawData(self.gsFont)
+            self._writeRawFontData()
+        finally:
+            self.gsFont.glyphs = originalGlyphs
 
     async def getBackgroundImage(self, imageIdentifier: str) -> ImageData | None:
         return None

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -303,7 +303,10 @@ class GlyphsBackend:
                 f"GlyphsApp Backend: Error while parsing features: {e}"
             )
 
-        self.rawFontData = self._getRawData(self.gsFont)
+        # Set self.gsFont.glyphs to an empty list temporarily, so no time is wasted on these.
+        gsFontTemp = deepcopy(self.gsFont)
+        gsFontTemp.glyphs = []
+        self.rawFontData = self._getRawData(gsFontTemp)
         self._writeRawFontData()
 
     async def getBackgroundImage(self, imageIdentifier: str) -> ImageData | None:

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -274,8 +274,9 @@ class GlyphsBackend:
         )
 
     async def getFeatures(self) -> OpenTypeFeatures:
-        self.featureText = glyphsLib.builder.features._to_ufo_features(self.gsFont)
-        return OpenTypeFeatures(language="fea", text=self.featureText)
+        return OpenTypeFeatures(
+            text=glyphsLib.builder.features._to_ufo_features(self.gsFont),
+        )
 
     async def putFeatures(self, features: OpenTypeFeatures) -> None:
         if features.language != "fea":

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -161,6 +161,9 @@ class GlyphsBackend:
             self.gsFont.format_version,
         )
 
+        ufos = glyphsLib.to_ufos(self.gsFont)
+        self.featureText = ufos[0].features.text
+
         axis: FontAxis | DiscreteFontAxis
         axes: list[FontAxis | DiscreteFontAxis] = []
         for dsAxis in dsAxes:
@@ -274,8 +277,7 @@ class GlyphsBackend:
         )
 
     async def getFeatures(self) -> OpenTypeFeatures:
-        # TODO: extract features
-        return OpenTypeFeatures()
+        return OpenTypeFeatures(language="fea", text=self.featureText)
 
     async def putFeatures(self, features: OpenTypeFeatures) -> None:
         raise NotImplementedError(

--- a/src/fontra_glyphs/backend.py
+++ b/src/fontra_glyphs/backend.py
@@ -161,9 +161,6 @@ class GlyphsBackend:
             self.gsFont.format_version,
         )
 
-        ufos = glyphsLib.to_ufos(self.gsFont)
-        self.featureText = ufos[0].features.text
-
         axis: FontAxis | DiscreteFontAxis
         axes: list[FontAxis | DiscreteFontAxis] = []
         for dsAxis in dsAxes:
@@ -277,6 +274,8 @@ class GlyphsBackend:
         )
 
     async def getFeatures(self) -> OpenTypeFeatures:
+        ufos = glyphsLib.to_ufos(self.gsFont)
+        self.featureText = ufos[0].features.text
         return OpenTypeFeatures(language="fea", text=self.featureText)
 
     async def putFeatures(self, features: OpenTypeFeatures) -> None:

--- a/tests/data/GlyphsUnitTestSans.glyphs
+++ b/tests/data/GlyphsUnitTestSans.glyphs
@@ -13,10 +13,6 @@ code = a.sc;
 name = c2sc_target;
 },
 {
-code = "";
-name = numbers;
-},
-{
 code = a;
 name = smcp_source;
 },
@@ -63,11 +59,11 @@ code = "feature c2sc;\012feature smcp;\012";
 name = aalt;
 },
 {
-code = "# Small Capitals From Capitals\012\012    sub @c2sc_source by @c2sc_target; ";
+code = "# Small Capitals From Capitals\012\012    sub @c2sc_source by @c2sc_target;";
 name = c2sc;
 },
 {
-code = "# Small Capitals\012\012    sub @smcp_source by @smcp_target; ";
+code = "# Small Capitals\012\012    sub @smcp_source by @smcp_target;";
 name = smcp;
 }
 );

--- a/tests/data/GlyphsUnitTestSans3.fontra/features.txt
+++ b/tests/data/GlyphsUnitTestSans3.fontra/features.txt
@@ -1,0 +1,43 @@
+@c2sc_source = [ A
+];
+
+@c2sc_target = [ a.sc
+];
+
+@smcp_source = [ a
+];
+
+@smcp_target = [ a.sc
+];
+
+# Prefix: Languagesystems
+# Dancing Shoes 0.1.4 OpenType feature code generator by Yanone, Copyright 2009
+# Code generated for AFDKO version 2.5
+
+
+languagesystem DFLT dflt; # Default, Default
+languagesystem latn dflt; # Latin, Default
+
+
+
+
+
+
+feature aalt {
+# automatic
+feature c2sc;
+feature smcp;
+
+} aalt;
+
+feature c2sc {
+# Small Capitals From Capitals
+
+    sub @c2sc_source by @c2sc_target;
+} c2sc;
+
+feature smcp {
+# Small Capitals
+
+    sub @smcp_source by @smcp_target;
+} smcp;

--- a/tests/data/GlyphsUnitTestSans3.glyphs
+++ b/tests/data/GlyphsUnitTestSans3.glyphs
@@ -21,10 +21,6 @@ code = a.sc;
 name = c2sc_target;
 },
 {
-code = "";
-name = numbers;
-},
-{
 code = a;
 name = smcp_source;
 },
@@ -81,13 +77,13 @@ tag = aalt;
 {
 code = "# Small Capitals From Capitals
 
-    sub @c2sc_source by @c2sc_target; ";
+    sub @c2sc_source by @c2sc_target;";
 tag = c2sc;
 },
 {
 code = "# Small Capitals
 
-    sub @smcp_source by @smcp_target; ";
+    sub @smcp_source by @smcp_target;";
 tag = smcp;
 }
 );

--- a/tests/data/GlyphsUnitTestSans3.glyphspackage/fontinfo.plist
+++ b/tests/data/GlyphsUnitTestSans3.glyphspackage/fontinfo.plist
@@ -17,10 +17,6 @@ code = a.sc;
 name = c2sc_target;
 },
 {
-code = "";
-name = numbers;
-},
-{
 code = a;
 name = smcp_source;
 },
@@ -77,13 +73,13 @@ tag = aalt;
 {
 code = "# Small Capitals From Capitals
 
-    sub @c2sc_source by @c2sc_target; ";
+    sub @c2sc_source by @c2sc_target;";
 tag = c2sc;
 },
 {
 code = "# Small Capitals
 
-    sub @smcp_source by @smcp_target; ";
+    sub @smcp_source by @smcp_target;";
 tag = smcp;
 }
 );

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -658,6 +658,10 @@ async def test_getKerning(testFont, referenceFont):
     assert await testFont.getKerning() == await referenceFont.getKerning()
 
 
+async def test_getFeatures(testFont, referenceFont):
+    assert await testFont.getFeatures() == await referenceFont.getFeatures()
+
+
 async def test_getSources(testFont, referenceFont):
     assert await testFont.getSources() == await referenceFont.getSources()
 


### PR DESCRIPTION
There is no issue for this PR.

Reading the feature code from a GlyphsApp file and converting it to 'feature text' is pretty straightforward with `glyphsLib.builder.features._to_ufo_features(self.gsFont)`.